### PR TITLE
DM-36565: Updates for current status and new risks

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -1,7 +1,5 @@
 :tocdepth: 1
 
-.. sectnum::
-
 .. _abstract:
 
 Abstract
@@ -19,10 +17,10 @@ This tech note proposes a threat model for analyzing the security risks of the S
 Scope
 =====
 
-This security risk assessment covers the Science Platform as defined by `LDM-542`_ and `LDM-554`_.
+This security risk assessment covers the Science Platform as defined by LDM-542_ and LDM-554_.
 It discusses Vera C. Rubin Observatory infrastructure only insofar as it supports the Science Platform and does not analyze the security of other project facilities.
 It also does not cover other installations of the Notebook Aspect of the Science Platform outside of the Science Platform itself, such as at the Summit facility or the various project-internal test facilities.
-For a related discussion of internal services maintained by the Science Quality and Reliability Engineering team, see `SQR-037`_.
+For a related discussion of internal services maintained by the Science Quality and Reliability Engineering team, see SQR-037_.
 
 .. _LDM-542: https://ldm-542.lsst.io/
 .. _LDM-554: https://ldm-554.lsst.io/
@@ -31,17 +29,13 @@ For a related discussion of internal services maintained by the Science Quality 
 This risk assessment only covers risks associated with the data that will be released for general users of the Science Platform.
 It does not discuss security risks of data and processing prior to or not included in that data release, such as prompt processing, unreleased raw images, security of the telescope itself and its related support equipment, or transfer of data to repositories used by the Science Pipeline.
 
-The authentication and authorization model for the Science Platform is still under development.
-(See `SQR-039`_, `SQR-044`_, `SQR-045`_, `SQR-046`_, `SQR-049`_, and `SQR-055`_ for current discussion.)
-This risk assessment therefore only deals with authentication and authorization at a high level and in generic terms.
-It will be revised to include a specific analysis of the authentication and authorization system as implemented once that implementation becomes more concrete.
+The authentication and authorization model for the Science Platform is discussed in detail in DMTN-234_, DMTN-224_, and SQR-069_.
+Those details will not be repeated here; instead, only known issues and limitations that affect the overall security of the platform will be noted.
+For a much deeper analysis of authentication and authorization, see those documents.
 
-.. _SQR-039: https://sqr-039.lsst.io/
-.. _SQR-044: https://sqr-044.lsst.io/
-.. _SQR-045: https://sqr-045.lsst.io/
-.. _SQR-046: https://sqr-046.lsst.io/
-.. _SQR-049: https://sqr-049.lsst.io/
-.. _SQR-055: https://sqr-055.lsst.io/
+.. _DMTN-234: https://dmtn-234.lsst.io/
+.. _DMTN-224: https://dmtn-224.lsst.io/
+.. _SQR-069: https://sqr-069.lsst.io/
 
 .. _summary:
 

--- a/index.rst
+++ b/index.rst
@@ -278,7 +278,7 @@ Recommendations
 .. _gap-databases:
 
 Infrastructure databases
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Risk: High**
 
@@ -1243,6 +1243,17 @@ References
 
 Changes
 =======
+
+2022-10-10
+----------
+
+- Add :ref:`Infrastructure data stores <gap-databases>` and mark it high risk.
+- Add :ref:`Butler data access <gap-butler-auth>` and mark it high risk.
+- Replace the recommendations section for :ref:`Dask access for notebooks <gap-dask>` with a reference to SQR-066_, and note SQR-066_ in discussions of other security recommendations that it would address.
+- Add a discussion of Kubernetes secrets to :ref:`accepted-risks`.
+- Replace references to ``PodSecurityPolicy`` (which has been deprecated) with references to the ``PodSecurity`` admission controller and Pod Security Standards.
+- Add a list of services that need work on pod hardening or ``NetworkPolicy``.
+- Reference the authentication and authorization document series for more details about user authentication.
 
 2021-12-17
 ----------

--- a/index.rst
+++ b/index.rst
@@ -1065,6 +1065,28 @@ Attempting to defend against this attack proactively is unlikely to be successfu
 
 We should therefore accept this risk.
 
+Use of Kubernetes secrets
+-------------------------
+
+Kubernetes has a built-in secret management interface using ``Secret`` objects.
+This interface provides easy injection of secrets into pods and use of the Kubernetes API to pass secrets between applications.
+It is also well-supported by third-party applications that integrate with long-term secret stores, such as Vault_ (via Vault Secrets Operator_).
+
+.. _Vault: https://www.vaultproject.io/
+.. _Vault Secrets Operator: https://github.com/ricoberger/vault-secrets-operator
+
+The drawback of Kubernetes secrets is that they're stored in the Kubernetes control plane, are accessible to any Kubernetes user with the necessary permissions, may or may not be encrypted at rest, and can easily be stolen if the Kubernetes control plane is compromised.
+They are also readily accessible via Kubernetes APIs that may be inobvious, such as by launching a pod in the same namespace and requesting the secret be mounted in the pod.
+Secrets are also provided to the pod via either environment variables or mounted files, both of which are easily accessible to all processes running in the pod.
+
+More sophisticated systems such as Vault can offer more protection for secrets if used directly instead of via Kubernetes secrets.
+Such systems lend themselves to being used with more care, such as by retrieving secrets only when necessary, storing them only in memory of a given process, and discarding them when they're no longer needed.
+
+However, the additional risk of using Kubernetes secrets is small and comparable to other risks around credential management that we're already accepting.
+The cost of a more sophisticated secret management system is relatively high, requiring injecting custom code into most applications and, depending on how thoroughly an alternate policy would be implemented, modifying third-party software used by the Rubin Science Platform.
+
+Given the relatively low risk and relatively high cost of alternatives, we should accept this risk.
+
 .. _glossary:
 
 Glossary


### PR DESCRIPTION
- Add Infrastructure data stores and mark it high risk.
- Add Butler data access and mark it high risk.
- Replace the recommendations section for Dask access for notebooks with a reference to SQR-066, and note SQR-066 in discussions of other security recommendations that it would address.
- Add a discussion of Kubernetes secrets to Accepted risks
- Replace references to `PodSecurityPolicy` (which has been deprecated) with references to the `PodSecurity` admission controller and Pod Security Standards.
- Add a list of services that need work on pod hardening or `NetworkPolicy`.
- Reference the authentication and authorization document series for more details about user authentication.
